### PR TITLE
disable supportsRtl

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
+        android:supportsRtl="false"
         android:enableOnBackInvokedCallback="true"
         android:theme="@style/Theme.QuickTools"
         tools:targetApi="31"


### PR DESCRIPTION
Since at this time the only translated languages are: ES, KO & PT-rBR none of which are RTL languages, and since this feature when enabled wrongly impose a RTL layout on English on devices whose set language is RTL, I suggest disabling this until a RTL translation is actually committed into the project.
